### PR TITLE
making REST API reflect global source.type.field

### DIFF
--- a/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
+++ b/metron-interface/metron-rest/src/main/java/org/apache/metron/rest/service/impl/SearchServiceImpl.java
@@ -23,19 +23,26 @@ import static org.apache.metron.rest.MetronRestConstants.INDEX_WRITER_NAME;
 import static org.apache.metron.rest.MetronRestConstants.SEARCH_FACET_FIELDS_SPRING_PROPERTY;
 
 import com.google.common.collect.Lists;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.metron.common.Constants;
 import org.apache.metron.indexing.dao.IndexDao;
+import org.apache.metron.indexing.dao.search.FieldType;
 import org.apache.metron.indexing.dao.search.GetRequest;
 import org.apache.metron.indexing.dao.search.GroupRequest;
 import org.apache.metron.indexing.dao.search.GroupResponse;
 import org.apache.metron.indexing.dao.search.InvalidSearchException;
 import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.indexing.dao.search.SearchResponse;
-import org.apache.metron.indexing.dao.search.FieldType;
 import org.apache.metron.rest.RestException;
 import org.apache.metron.rest.model.AlertsUIUserSettings;
 import org.apache.metron.rest.service.AlertsUIService;
+import org.apache.metron.rest.service.GlobalConfigService;
 import org.apache.metron.rest.service.SearchService;
 import org.apache.metron.rest.service.SensorIndexingConfigService;
 import org.slf4j.Logger;
@@ -43,11 +50,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.Optional;
-import java.util.List;
 
 @Service
 public class SearchServiceImpl implements SearchService {
@@ -57,14 +59,19 @@ public class SearchServiceImpl implements SearchService {
   private IndexDao dao;
   private Environment environment;
   private SensorIndexingConfigService sensorIndexingConfigService;
+  private GlobalConfigService globalConfigService;
   private AlertsUIService alertsUIService;
 
   @Autowired
-  public SearchServiceImpl(IndexDao dao, Environment environment,
-      SensorIndexingConfigService sensorIndexingConfigService, AlertsUIService alertsUIService) {
+  public SearchServiceImpl(IndexDao dao,
+      Environment environment,
+      SensorIndexingConfigService sensorIndexingConfigService,
+      GlobalConfigService globalConfigService,
+      AlertsUIService alertsUIService) {
     this.dao = dao;
     this.environment = environment;
     this.sensorIndexingConfigService = sensorIndexingConfigService;
+    this.globalConfigService = globalConfigService;
     this.alertsUIService = alertsUIService;
   }
 
@@ -133,11 +140,21 @@ public class SearchServiceImpl implements SearchService {
     return indices;
   }
 
-  private List<String> getDefaultFacetFields() throws RestException {
+  public List<String> getDefaultFacetFields() throws RestException {
     Optional<AlertsUIUserSettings> alertUserSettings = alertsUIService.getAlertsUIUserSettings();
     if (!alertUserSettings.isPresent() || alertUserSettings.get().getFacetFields() == null) {
-      String facetFieldsProperty = environment.getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, "");
-      return Arrays.asList(facetFieldsProperty.split(","));
+      String facetFieldsProperty = environment
+          .getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, "");
+
+      @SuppressWarnings("unchecked")
+      String sourceTypeField = (String) globalConfigService.get()
+          .getOrDefault("source.type.field", Constants.SENSOR_TYPE.replace('.', ':'));
+      List<String> facetFields = new ArrayList<>();
+      facetFields.add(sourceTypeField);
+      if (facetFieldsProperty != null) {
+        facetFields.addAll(Arrays.asList(facetFieldsProperty.split(",")));
+      }
+      return facetFields;
     } else {
       return alertUserSettings.get().getFacetFields();
     }

--- a/metron-interface/metron-rest/src/main/resources/application.yml
+++ b/metron-interface/metron-rest/src/main/resources/application.yml
@@ -51,7 +51,7 @@ search:
     results: 1000
     groups: 1000
   facet:
-    fields: source:type,ip_src_addr,ip_dst_addr,enrichments:geo:ip_dst_addr:country
+    fields: ip_src_addr,ip_dst_addr,enrichments:geo:ip_dst_addr:country
 
 index:
   dao:

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SearchControllerIntegrationTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/controller/SearchControllerIntegrationTest.java
@@ -37,6 +37,7 @@ import org.apache.metron.indexing.dao.InMemoryDao;
 import org.apache.metron.indexing.dao.SearchIntegrationTest;
 import org.apache.metron.indexing.dao.search.FieldType;
 import org.apache.metron.rest.service.AlertsUIService;
+import org.apache.metron.rest.service.GlobalConfigService;
 import org.apache.metron.rest.service.SensorIndexingConfigService;
 import org.json.simple.parser.ParseException;
 import org.junit.After;
@@ -85,6 +86,9 @@ public class SearchControllerIntegrationTest extends DaoControllerTest {
 
   @Autowired
   private SensorIndexingConfigService sensorIndexingConfigService;
+
+  @Autowired
+  private GlobalConfigService globalConfigService;
 
   @Autowired
   private AlertsUIService alertsUIService;
@@ -141,7 +145,9 @@ public class SearchControllerIntegrationTest extends DaoControllerTest {
             .andExpect(jsonPath("$.results[3].source.timestamp").value(2))
             .andExpect(jsonPath("$.results[4].source.source:type").value("bro"))
             .andExpect(jsonPath("$.results[4].source.timestamp").value(1))
-            .andExpect(jsonPath("$.facetCounts.*", hasSize(1)))
+            .andExpect(jsonPath("$.facetCounts.*", hasSize(2)))
+            .andExpect(jsonPath("$.facetCounts.source:type.*", hasSize(1)))
+            .andExpect(jsonPath("$.facetCounts.source:type['bro']").value(5))
             .andExpect(jsonPath("$.facetCounts.ip_src_addr.*", hasSize(2)))
             .andExpect(jsonPath("$.facetCounts.ip_src_addr['192.168.1.1']").value(3))
             .andExpect(jsonPath("$.facetCounts.ip_src_addr['192.168.1.2']").value(1))
@@ -366,8 +372,12 @@ public class SearchControllerIntegrationTest extends DaoControllerTest {
     Map<String, Long> ipSrcPortCounts = new HashMap<>();
     ipSrcPortCounts.put("8010", 1L);
     ipSrcPortCounts.put("8009", 2L);
+    Map<String, Long> sourceTypeCounts = new HashMap<>();
+    sourceTypeCounts.put("bro", 5L);
     facetCounts.put("ip_src_addr", ipSrcAddrCounts);
     facetCounts.put("ip_src_port", ipSrcPortCounts);
+    facetCounts.put("source:type", sourceTypeCounts);
+
     InMemoryDao.setFacetCounts(facetCounts);
   }
 

--- a/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SearchServiceImplTest.java
+++ b/metron-interface/metron-rest/src/test/java/org/apache/metron/rest/service/impl/SearchServiceImplTest.java
@@ -19,6 +19,7 @@ package org.apache.metron.rest.service.impl;
 
 import static org.apache.metron.rest.MetronRestConstants.INDEX_WRITER_NAME;
 import static org.apache.metron.rest.MetronRestConstants.SEARCH_FACET_FIELDS_SPRING_PROPERTY;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -28,15 +29,17 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-
 import org.apache.metron.indexing.dao.IndexDao;
 import org.apache.metron.indexing.dao.search.InvalidSearchException;
 import org.apache.metron.indexing.dao.search.SearchRequest;
 import org.apache.metron.rest.RestException;
 import org.apache.metron.rest.model.AlertsUIUserSettings;
 import org.apache.metron.rest.service.AlertsUIService;
-import org.apache.metron.rest.service.SearchService;
+import org.apache.metron.rest.service.GlobalConfigService;
 import org.apache.metron.rest.service.SensorIndexingConfigService;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,16 +55,24 @@ public class SearchServiceImplTest {
   IndexDao dao;
   Environment environment;
   SensorIndexingConfigService sensorIndexingConfigService;
+  GlobalConfigService globalConfigService;
   AlertsUIService alertsUIService;
-  SearchService searchService;
+  SearchServiceImpl searchService;
 
   @Before
   public void setUp() throws Exception {
     dao = mock(IndexDao.class);
     environment = mock(Environment.class);
     sensorIndexingConfigService = mock(SensorIndexingConfigService.class);
+    globalConfigService = mock(GlobalConfigService.class);
     alertsUIService = mock(AlertsUIService.class);
-    searchService = new SearchServiceImpl(dao, environment, sensorIndexingConfigService, alertsUIService);
+    searchService = new SearchServiceImpl(
+        dao,
+        environment,
+        sensorIndexingConfigService,
+        globalConfigService,
+        alertsUIService
+    );
   }
 
 
@@ -97,7 +108,7 @@ public class SearchServiceImplTest {
   @Test
   public void searchShouldProperlySearchDefaultFacetFields() throws Exception {
     when(environment.getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, ""))
-        .thenReturn("source:type,ip_src_addr");
+        .thenReturn("ip_src_addr,ip_dst_addr");
     when(alertsUIService.getAlertsUIUserSettings()).thenReturn(Optional.empty());
 
     SearchRequest searchRequest = new SearchRequest();
@@ -107,14 +118,14 @@ public class SearchServiceImplTest {
 
     SearchRequest expectedSearchRequest = new SearchRequest();
     expectedSearchRequest.setIndices(Arrays.asList("bro", "snort", "metaalert"));
-    expectedSearchRequest.setFacetFields(Arrays.asList("source:type", "ip_src_addr"));
+    expectedSearchRequest.setFacetFields(Arrays.asList("source:type", "ip_src_addr", "ip_dst_addr"));
     verify(dao).search(eq(expectedSearchRequest));
   }
 
   @Test
   public void searchShouldProperlySearchWithUserSettingsFacetFields() throws Exception {
     AlertsUIUserSettings alertsUIUserSettings = new AlertsUIUserSettings();
-    alertsUIUserSettings.setFacetFields(Arrays.asList("source:type", "ip_dst_addr"));
+    alertsUIUserSettings.setFacetFields(Arrays.asList("ip_src_addr", "ip_dst_addr"));
     when(alertsUIService.getAlertsUIUserSettings()).thenReturn(Optional.of(alertsUIUserSettings));
 
     SearchRequest searchRequest = new SearchRequest();
@@ -124,7 +135,7 @@ public class SearchServiceImplTest {
 
     SearchRequest expectedSearchRequest = new SearchRequest();
     expectedSearchRequest.setIndices(Arrays.asList("bro", "snort", "metaalert"));
-    expectedSearchRequest.setFacetFields(Arrays.asList("source:type", "ip_dst_addr"));
+    expectedSearchRequest.setFacetFields(Arrays.asList("ip_src_addr", "ip_dst_addr"));
     verify(dao).search(eq(expectedSearchRequest));
   }
 
@@ -165,5 +176,38 @@ public class SearchServiceImplTest {
     verify(dao).getColumnMetadata(eq(Arrays.asList("bro", "snort", "metaalert")));
 
     verifyNoMoreInteractions(dao);
+  }
+
+  @Test
+  public void testGetDefaultFacetFieldsGlobalConfig() throws RestException {
+    when(environment.getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, ""))
+        .thenReturn("ip_src_addr");
+    Map<String, Object> globalConfig = new HashMap<>();
+    globalConfig.put("source.type.field", "source.type");
+    when(globalConfigService.get()).thenReturn(globalConfig);
+    when(alertsUIService.getAlertsUIUserSettings()).thenReturn(Optional.empty());
+    List<String> defaultFields = searchService.getDefaultFacetFields();
+
+    List<String> expectedFields = new ArrayList<>();
+    expectedFields.add("source.type");
+    expectedFields.add("ip_src_addr");
+
+    assertEquals(expectedFields, defaultFields);
+  }
+
+  @Test
+  public void testGetDefaultFacetFieldsEmptyGlobalConfig() throws RestException {
+    when(environment.getProperty(SEARCH_FACET_FIELDS_SPRING_PROPERTY, String.class, ""))
+        .thenReturn("ip_src_addr");
+    Map<String, Object> globalConfig = new HashMap<>();
+    when(globalConfigService.get()).thenReturn(globalConfig);
+    when(alertsUIService.getAlertsUIUserSettings()).thenReturn(Optional.empty());
+    List<String> defaultFields = searchService.getDefaultFacetFields();
+
+    List<String> expectedFields = new ArrayList<>();
+    expectedFields.add("source:type");
+    expectedFields.add("ip_src_addr");
+
+    assertEquals(expectedFields, defaultFields);
   }
 }


### PR DESCRIPTION
Lets the REST API pull the `source.type.field` from the global config and set the default facet fields appropriately.  Given that the fields were hardcoded in the application.yml, I just removed `source:type`, and moved it into code.

Tests are updated to reflect this change.
